### PR TITLE
Typing improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,6 @@ setup(
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    include_package_data=True,
     test_suite="isodate.tests.test_suite",
 )

--- a/src/isodate/duration.py
+++ b/src/isodate/duration.py
@@ -4,6 +4,8 @@ This module defines a Duration class.
 The class Duration allows to define durations in years and months and can be
 used as limited replacement for timedelta objects.
 """
+from __future__ import annotations
+
 from datetime import date, datetime, timedelta
 from decimal import Decimal, ROUND_FLOOR
 
@@ -144,7 +146,7 @@ class Duration:
         negduration.tdelta = -self.tdelta
         return negduration
 
-    def __add__(self, other: "Duration | timedelta | date | datetime") -> "Duration | date | datetime":
+    def __add__(self, other: Duration | timedelta | date | datetime) -> Duration | date | datetime:
         """
         Durations can be added with Duration, timedelta, date and datetime
         objects.
@@ -193,7 +195,7 @@ class Duration:
 
     __radd__ = __add__
 
-    def __mul__(self, other: int) -> "Duration":
+    def __mul__(self, other: int) -> Duration:
         if isinstance(other, int):
             newduration = Duration(years=self.years * other, months=self.months * other)
             newduration.tdelta = self.tdelta * other
@@ -202,7 +204,7 @@ class Duration:
 
     __rmul__ = __mul__
 
-    def __sub__(self, other: "Duration | timedelta") -> "Duration":
+    def __sub__(self, other: Duration | timedelta) -> Duration:
         """
         It is possible to subtract Duration and timedelta objects from Duration
         objects.
@@ -223,7 +225,7 @@ class Duration:
             pass
         return NotImplemented
 
-    def __rsub__(self, other: "Duration | date | datetime | timedelta"):
+    def __rsub__(self, other: Duration | date | datetime | timedelta):
         """
         It is possible to subtract Duration objects from date, datetime and
         timedelta objects.
@@ -265,7 +267,7 @@ class Duration:
             pass
         return NotImplemented
 
-    def __eq__(self, other: "Duration | timedelta"):
+    def __eq__(self, other: object):
         """
         If the years, month part and the timedelta part are both equal, then
         the two Durations are considered equal.
@@ -282,7 +284,7 @@ class Duration:
             return self.tdelta == other
         return False
 
-    def __ne__(self, other: "Duration | timedelta"):
+    def __ne__(self, other: object):
         """
         If the years, month part or the timedelta part is not equal, then
         the two Durations are considered not equal.

--- a/src/isodate/isodates.py
+++ b/src/isodate/isodates.py
@@ -6,6 +6,8 @@ It supports all basic, extended and expanded formats as described in the ISO
 standard. The only limitations it has, are given by the Python datetime.date
 implementation, which does not support dates before 0001-01-01.
 """
+from __future__ import annotations
+
 import re
 from datetime import date, time, timedelta
 
@@ -35,7 +37,7 @@ def build_date_regexps(yeardigits: int=4, expanded: bool=False) -> list[re.Patte
     if yeardigits != 4:
         expanded = True
     if (yeardigits, expanded) not in DATE_REGEX_CACHE:
-        cache_entry = list[re.Pattern[str]]()
+        cache_entry: list[re.Pattern[str]] = []
         # ISO 8601 expanded DATE formats allow an arbitrary number of year
         # digits with a leading +/- sign.
         if expanded:

--- a/src/isodate/isodatetime.py
+++ b/src/isodate/isodatetime.py
@@ -4,6 +4,8 @@ This module defines a method to parse an ISO 8601:2004 date time string.
 For this job it uses the parse_date and parse_time methods defined in date
 and time module.
 """
+from __future__ import annotations
+
 from datetime import date, datetime, time, timedelta
 
 from isodate.duration import Duration

--- a/src/isodate/isoduration.py
+++ b/src/isodate/isoduration.py
@@ -4,6 +4,8 @@ This module provides an ISO 8601:2004 duration parser.
 It also provides a wrapper to strftime. This wrapper makes it easier to
 format timedelta or Duration instances as ISO conforming strings.
 """
+from __future__ import annotations
+
 from datetime import date, time, timedelta
 from decimal import Decimal
 import re

--- a/src/isodate/isostrf.py
+++ b/src/isodate/isostrf.py
@@ -7,6 +7,8 @@ possible with standard Python date/time objects. Furthermore there are several
 pr-defined format strings in this module to make ease producing of ISO 8601
 conforming strings.
 """
+from __future__ import annotations
+
 import re
 from datetime import date, time, timedelta
 from typing import Callable
@@ -106,7 +108,7 @@ def _strfduration(tdt: timedelta | Duration, format: str, yeardigits: int=4) -> 
         if match.group(0) in STRF_D_MAP:
             return STRF_D_MAP[match.group(0)](tdt, yeardigits)
         elif match.group(0) == "%P":
-            ret = list[str]()
+            ret: list[str] = []
             if isinstance(tdt, Duration):
                 if tdt.years:
                     ret.append("%sY" % abs(tdt.years))

--- a/src/isodate/isotime.py
+++ b/src/isodate/isotime.py
@@ -5,16 +5,19 @@ Python datetime.time instance.
 It supports all basic and extended formats including time zone specifications
 as described in the ISO standard.
 """
+from __future__ import annotations
+
 import re
 from decimal import Decimal, ROUND_FLOOR
 from datetime import date, time, timedelta
+from typing import TYPE_CHECKING
 
 from isodate.duration import Duration
 from isodate.isostrf import strftime, TIME_EXT_COMPLETE, TZ_EXT
 from isodate.isoerror import ISO8601Error
 from isodate.isotzinfo import TZ_REGEX, build_tzinfo
 
-TIME_REGEX_CACHE = list[re.Pattern[str]]()
+TIME_REGEX_CACHE: list[re.Pattern[str]] = []
 # used to cache regular expressions to parse ISO time strings.
 
 

--- a/src/isodate/isotzinfo.py
+++ b/src/isodate/isotzinfo.py
@@ -3,12 +3,17 @@ This module provides an ISO 8601:2004 time zone info parser.
 
 It offers a function to parse the time zone offset as specified by ISO 8601.
 """
-from datetime import datetime, tzinfo
+from __future__ import annotations
+
 import re
-from typing import Literal, overload
+from typing import overload, TYPE_CHECKING
+from datetime import datetime, tzinfo
 
 from isodate.isoerror import ISO8601Error
 from isodate.tzinfo import UTC, FixedOffset, ZERO, Utc
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 TZ_REGEX = (
     r"(?P<tzname>(Z|(?P<tzsign>[+-])" r"(?P<tzhour>[0-9]{2})(:?(?P<tzmin>[0-9]{2}))?)?)"

--- a/src/isodate/tzinfo.py
+++ b/src/isodate/tzinfo.py
@@ -3,9 +3,14 @@ This module provides some datetime.tzinfo implementations.
 
 All those classes are taken from the Python documentation.
 """
-from datetime import datetime, timedelta, tzinfo
+from __future__ import annotations
+
 import time
-from typing import Literal
+from typing import Callable, TYPE_CHECKING
+from datetime import datetime, timedelta, tzinfo
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 ZERO = timedelta(0)
 # constant for zero time offset.


### PR DESCRIPTION
- fix: parsing type annotations on python 3.7 interpreter
  - setup.py declares compatibility with python>=3.7
  - Assuming we want to maintain compatibility, apply the following changes:
    - Treat annotations as opaque str at runtime: `from __future__ import annotations`
    - The above lets us use new syntax such as `list[foo]` in Python<3.9 and remove explicit quotes around some existing annotations
    - Import `Literal` not in Python3.7(EOL) from typing_extensions (if we bump compatibility to Python>=3.8 we can avoid doing this)

- build: Adding py.typed to wheel builds
  - We were missing `include_package_data=True` in setup.py