### PR TITLE
Improve type annotations and type-check in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["pypy-3.8", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v2.29.1
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,13 @@ repos:
         args:
           - "--max-line-length=88"
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.5.1'
+    hooks:
+    -   id: mypy
+        additional_dependencies: [types-setuptools]
+        args: [--strict, --python-version=3.8]
+
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0
     hooks:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     # keywords = '',
     url="https://github.com/gweis/isodate/",
     long_description=(read("README.rst") + read("CHANGES.txt") + read("TODO.txt")),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 4 - Beta",
         # 'Environment :: Web Environment',
@@ -31,7 +31,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup
 
 
-def read(*rnames):
+def read(*rnames: str) -> str:
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as read_file:
         return read_file.read()
 

--- a/src/isodate/duration.py
+++ b/src/isodate/duration.py
@@ -177,7 +177,7 @@ class Duration:
             # try anything that looks like a date or datetime
             # 'other' has attributes year, month, day
             # and relies on 'timedelta + other' being implemented
-            other_date: date = cast(date, other)
+            other_date = cast(date, other)  # silence mypy, runtime uses try-except
             if not (float(self.years).is_integer() and float(self.months).is_integer()):
                 raise ValueError(
                     "fractional years or months not supported" " for date calculations"
@@ -201,7 +201,7 @@ class Duration:
         try:
             # try if other is a timedelta
             # relies on timedelta + timedelta supported
-            other_timedelta: timedelta = cast(timedelta, other)
+            other_timedelta = cast(timedelta, other)  # silence mypy, runtime uses try
             newduration = Duration(years=self.years, months=self.months)
             newduration.tdelta = self.tdelta + other_timedelta
             return newduration

--- a/src/isodate/duration.py
+++ b/src/isodate/duration.py
@@ -6,11 +6,21 @@ used as limited replacement for timedelta objects.
 """
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from decimal import Decimal, ROUND_FLOOR
+from typing import Any, cast, overload, TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 
-def fquotmod(val: Decimal, low: int, high: int):
+# The _DateT TypeVar represents datetime.date or its subclass datetime.datetime
+_DateT = TypeVar("_DateT", bound=date)
+
+DurationOrTimedelta: TypeAlias = "Duration | timedelta"
+
+
+def fquotmod(val: Decimal, low: int, high: int) -> tuple[int, Decimal]:
     """
     A divmod function with boundaries.
 
@@ -27,7 +37,7 @@ def fquotmod(val: Decimal, low: int, high: int):
     return int(div), mod
 
 
-def max_days_in_month(year, month):
+def max_days_in_month(year: Decimal, month: Decimal) -> int:
     """
     Determines the number of days of a specific month in a specific year.
     """
@@ -65,15 +75,15 @@ class Duration:
 
     def __init__(
         self,
-        days: float=0,
-        seconds: float=0,
-        microseconds: float=0,
-        milliseconds: float=0,
-        minutes: float=0,
-        hours: float=0,
-        weeks: float=0,
-        months: float | Decimal=0,
-        years: float | Decimal=0,
+        days: float = 0,
+        seconds: float = 0,
+        microseconds: float = 0,
+        milliseconds: float = 0,
+        minutes: float = 0,
+        hours: float = 0,
+        weeks: float = 0,
+        months: float | Decimal = 0,
+        years: float | Decimal = 0,
     ):
         """
         Initialise this Duration instance with the given parameters.
@@ -88,23 +98,23 @@ class Duration:
             days, seconds, microseconds, milliseconds, minutes, hours, weeks
         )
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         return self.__dict__
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
 
-    def __getattr__(self, name: str):
+    def __getattr__(self, name: str) -> Any:
         """
         Provide direct access to attributes of included timedelta instance.
         """
         return getattr(self.tdelta, name)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return a string representation of this duration similar to timedelta.
         """
-        params = list[str]()
+        params: list[str] = []
         if self.years:
             params.append("%d years" % self.years)
         if self.months:
@@ -115,7 +125,7 @@ class Duration:
         params.append(str(self.tdelta))
         return ", ".join(params)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Return a string suitable for repr(x) calls.
         """
@@ -129,14 +139,14 @@ class Duration:
             self.months,
         )
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """
         Return a hash of this instance so that it can be used in, for
         example, dicts and sets.
         """
         return hash((self.tdelta, self.months, self.years))
 
-    def __neg__(self):
+    def __neg__(self) -> Duration:
         """
         A simple unary minus.
 
@@ -146,8 +156,14 @@ class Duration:
         negduration.tdelta = -self.tdelta
         return negduration
 
-    def __add__(self, other: Duration | timedelta | date | datetime) -> Duration | date | datetime:
-        """
+    @overload
+    def __add__(self, other: DurationOrTimedelta) -> Duration: ...
+
+    @overload
+    def __add__(self, other: _DateT) -> _DateT: ...
+
+    def __add__(self, other: date | DurationOrTimedelta) -> date | Duration:
+        """timedelta
         Durations can be added with Duration, timedelta, date and datetime
         objects.
         """
@@ -161,19 +177,20 @@ class Duration:
             # try anything that looks like a date or datetime
             # 'other' has attributes year, month, day
             # and relies on 'timedelta + other' being implemented
+            other_date: date = cast(date, other)
             if not (float(self.years).is_integer() and float(self.months).is_integer()):
                 raise ValueError(
                     "fractional years or months not supported" " for date calculations"
                 )
-            newmonth = other.month + self.months
+            newmonth = other_date.month + self.months
             carry, newmonth = fquotmod(newmonth, 1, 13)
-            newyear = other.year + self.years + carry
+            newyear = other_date.year + self.years + carry
             maxdays = max_days_in_month(newyear, newmonth)
-            if other.day > maxdays:
+            if other_date.day > maxdays:
                 newday = maxdays
             else:
-                newday = other.day
-            newdt = other.replace(
+                newday = other_date.day
+            newdt = other_date.replace(
                 year=int(newyear), month=int(newmonth), day=int(newday)
             )
             # does a timedelta + date/datetime
@@ -184,8 +201,9 @@ class Duration:
         try:
             # try if other is a timedelta
             # relies on timedelta + timedelta supported
+            other_timedelta: timedelta = cast(timedelta, other)
             newduration = Duration(years=self.years, months=self.months)
-            newduration.tdelta = self.tdelta + other
+            newduration.tdelta = self.tdelta + other_timedelta
             return newduration
         except AttributeError:
             # ignore ... other probably was not a timedelta compatible object
@@ -204,7 +222,8 @@ class Duration:
 
     __rmul__ = __mul__
 
-    def __sub__(self, other: Duration | timedelta) -> Duration:
+    def __sub__(self, other: DurationOrTimedelta) -> Duration:
+
         """
         It is possible to subtract Duration and timedelta objects from Duration
         objects.
@@ -225,7 +244,13 @@ class Duration:
             pass
         return NotImplemented
 
-    def __rsub__(self, other: Duration | date | datetime | timedelta):
+    @overload
+    def __rsub__(self, other: _DateT) -> _DateT: ...
+
+    @overload
+    def __rsub__(self, other: timedelta) -> Duration: ...
+
+    def __rsub__(self, other: date | timedelta) -> date | Duration:
         """
         It is possible to subtract Duration objects from date, datetime and
         timedelta objects.
@@ -267,7 +292,7 @@ class Duration:
             pass
         return NotImplemented
 
-    def __eq__(self, other: object):
+    def __eq__(self, other: object) -> bool:
         """
         If the years, month part and the timedelta part are both equal, then
         the two Durations are considered equal.
@@ -284,7 +309,7 @@ class Duration:
             return self.tdelta == other
         return False
 
-    def __ne__(self, other: object):
+    def __ne__(self, other: object) -> bool:
         """
         If the years, month part or the timedelta part is not equal, then
         the two Durations are considered not equal.
@@ -301,7 +326,16 @@ class Duration:
             return self.tdelta != other
         return True
 
-    def totimedelta(self, start: date | datetime | None=None, end: date | datetime | None=None) -> timedelta:
+    @overload
+    def totimedelta(self, start: date, end: None = None) -> timedelta: ...
+
+    @overload
+    def totimedelta(self, start: None, end: date) -> timedelta: ...
+
+    def totimedelta(self,
+                    start: date | None = None,
+                    end: date | None = None,
+                    ) -> timedelta:
         """
         Convert this duration into a timedelta object.
 
@@ -314,4 +348,5 @@ class Duration:
             raise ValueError("only start or end allowed")
         if start is not None:
             return (start + self) - start
+        assert end is not None
         return end - (end - self)

--- a/src/isodate/isodates.py
+++ b/src/isodate/isodates.py
@@ -10,19 +10,22 @@ from __future__ import annotations
 
 import re
 from datetime import date, time, timedelta
+from typing import Sequence
 
-from isodate.duration import Duration
+from isodate.duration import DurationOrTimedelta
 from isodate.isostrf import strftime, DATE_EXT_COMPLETE
 from isodate.isoerror import ISO8601Error
 
-DATE_REGEX_CACHE: dict[tuple[int, bool], list[re.Pattern[str]]] = {}
+DATE_REGEX_CACHE: dict[tuple[int, bool], Sequence[re.Pattern[str]]] = {}
 # A dictionary to cache pre-compiled regular expressions.
 # A set of regular expressions is identified, by number of year digits allowed
 # and whether a plus/minus sign is required or not. (This option is changeable
 # only for 4 digit years).
 
 
-def build_date_regexps(yeardigits: int=4, expanded: bool=False) -> list[re.Pattern[str]]:
+def build_date_regexps(yeardigits: int = 4,
+                       expanded: bool = False,
+                       ) -> Sequence[re.Pattern[str]]:
     """
     Compile set of regular expressions to parse ISO dates. The expressions will
     be created only if they are not already in REGEX_CACHE.
@@ -118,7 +121,12 @@ def build_date_regexps(yeardigits: int=4, expanded: bool=False) -> list[re.Patte
     return DATE_REGEX_CACHE[(yeardigits, expanded)]
 
 
-def parse_date(datestring: str, yeardigits: int=4, expanded: bool=False, defaultmonth: int=1, defaultday: int=1) -> date:
+def parse_date(datestring: str,
+               yeardigits: int = 4,
+               expanded: bool = False,
+               defaultmonth: int = 1,
+               defaultday: int = 1,
+               ) -> date:
     """
     Parse an ISO 8601 date string into a datetime.date object.
 
@@ -195,7 +203,10 @@ def parse_date(datestring: str, yeardigits: int=4, expanded: bool=False, default
     raise ISO8601Error("Unrecognised ISO 8601 date format: %r" % datestring)
 
 
-def date_isoformat(tdate: timedelta | Duration | time | date, format: str=DATE_EXT_COMPLETE, yeardigits: int=4) -> str:
+def date_isoformat(tdate: DurationOrTimedelta | time | date,
+                   format: str = DATE_EXT_COMPLETE,
+                   yeardigits: int = 4
+                   ) -> str:
     """
     Format date strings.
 

--- a/src/isodate/isodatetime.py
+++ b/src/isodate/isodatetime.py
@@ -6,9 +6,9 @@ and time module.
 """
 from __future__ import annotations
 
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time
 
-from isodate.duration import Duration
+from isodate.duration import DurationOrTimedelta
 from isodate.isostrf import strftime
 from isodate.isostrf import DATE_EXT_COMPLETE, TIME_EXT_COMPLETE, TZ_EXT
 from isodate.isodates import parse_date
@@ -37,7 +37,8 @@ def parse_datetime(datetimestring: str) -> datetime:
 
 
 def datetime_isoformat(
-    tdt: timedelta | Duration | time | date, format: str=DATE_EXT_COMPLETE + "T" + TIME_EXT_COMPLETE + TZ_EXT
+        tdt: DurationOrTimedelta | time | date,
+        format: str = DATE_EXT_COMPLETE + "T" + TIME_EXT_COMPLETE + TZ_EXT
 ) -> str:
     """
     Format datetime strings.

--- a/src/isodate/isoduration.py
+++ b/src/isodate/isoduration.py
@@ -43,6 +43,12 @@ def parse_duration(datestring: str,
                    ) -> Duration: ...
 
 
+@overload
+def parse_duration(datestring: str,
+                   as_timedelta_if_possible: bool = True
+                   ) -> DurationOrTimedelta: ...
+
+
 def parse_duration(datestring: str,
                    as_timedelta_if_possible: bool = True
                    ) -> DurationOrTimedelta:

--- a/src/isodate/isostrf.py
+++ b/src/isodate/isostrf.py
@@ -11,54 +11,55 @@ from __future__ import annotations
 
 import re
 from datetime import date, time, timedelta
-from typing import Callable
+from typing import Callable, Final, Mapping
 
-from isodate.duration import Duration
+from isodate.duration import Duration, DurationOrTimedelta
 from isodate.isotzinfo import tz_isoformat
 
+
 # Date specific format strings
-DATE_BAS_COMPLETE = "%Y%m%d"
-DATE_EXT_COMPLETE = "%Y-%m-%d"
-DATE_BAS_WEEK_COMPLETE = "%YW%W%w"
-DATE_EXT_WEEK_COMPLETE = "%Y-W%W-%w"
-DATE_BAS_ORD_COMPLETE = "%Y%j"
-DATE_EXT_ORD_COMPLETE = "%Y-%j"
-DATE_BAS_WEEK = "%YW%W"
-DATE_EXT_WEEK = "%Y-W%W"
-DATE_BAS_MONTH = "%Y%m"
-DATE_EXT_MONTH = "%Y-%m"
-DATE_YEAR = "%Y"
-DATE_CENTURY = "%C"
+DATE_BAS_COMPLETE: Final = "%Y%m%d"
+DATE_EXT_COMPLETE: Final = "%Y-%m-%d"
+DATE_BAS_WEEK_COMPLETE: Final = "%YW%W%w"
+DATE_EXT_WEEK_COMPLETE: Final = "%Y-W%W-%w"
+DATE_BAS_ORD_COMPLETE: Final = "%Y%j"
+DATE_EXT_ORD_COMPLETE: Final = "%Y-%j"
+DATE_BAS_WEEK: Final = "%YW%W"
+DATE_EXT_WEEK: Final = "%Y-W%W"
+DATE_BAS_MONTH: Final = "%Y%m"
+DATE_EXT_MONTH: Final = "%Y-%m"
+DATE_YEAR: Final = "%Y"
+DATE_CENTURY: Final = "%C"
 
 # Time specific format strings
-TIME_BAS_COMPLETE = "%H%M%S"
-TIME_EXT_COMPLETE = "%H:%M:%S"
-TIME_BAS_MINUTE = "%H%M"
-TIME_EXT_MINUTE = "%H:%M"
-TIME_HOUR = "%H"
+TIME_BAS_COMPLETE: Final = "%H%M%S"
+TIME_EXT_COMPLETE: Final = "%H:%M:%S"
+TIME_BAS_MINUTE: Final = "%H%M"
+TIME_EXT_MINUTE: Final = "%H:%M"
+TIME_HOUR: Final = "%H"
 
 # Time zone formats
-TZ_BAS = "%z"
-TZ_EXT = "%Z"
-TZ_HOUR = "%h"
+TZ_BAS: Final = "%z"
+TZ_EXT: Final = "%Z"
+TZ_HOUR: Final = "%h"
 
 # DateTime formats
-DT_EXT_COMPLETE = DATE_EXT_COMPLETE + "T" + TIME_EXT_COMPLETE + TZ_EXT
-DT_BAS_COMPLETE = DATE_BAS_COMPLETE + "T" + TIME_BAS_COMPLETE + TZ_BAS
-DT_EXT_ORD_COMPLETE = DATE_EXT_ORD_COMPLETE + "T" + TIME_EXT_COMPLETE + TZ_EXT
-DT_BAS_ORD_COMPLETE = DATE_BAS_ORD_COMPLETE + "T" + TIME_BAS_COMPLETE + TZ_BAS
-DT_EXT_WEEK_COMPLETE = DATE_EXT_WEEK_COMPLETE + "T" + TIME_EXT_COMPLETE + TZ_EXT
-DT_BAS_WEEK_COMPLETE = DATE_BAS_WEEK_COMPLETE + "T" + TIME_BAS_COMPLETE + TZ_BAS
+DT_EXT_COMPLETE: Final = DATE_EXT_COMPLETE + "T" + TIME_EXT_COMPLETE + TZ_EXT
+DT_BAS_COMPLETE: Final = DATE_BAS_COMPLETE + "T" + TIME_BAS_COMPLETE + TZ_BAS
+DT_EXT_ORD_COMPLETE: Final = DATE_EXT_ORD_COMPLETE + "T" + TIME_EXT_COMPLETE + TZ_EXT
+DT_BAS_ORD_COMPLETE: Final = DATE_BAS_ORD_COMPLETE + "T" + TIME_BAS_COMPLETE + TZ_BAS
+DT_EXT_WEEK_COMPLETE: Final = DATE_EXT_WEEK_COMPLETE + "T" + TIME_EXT_COMPLETE + TZ_EXT
+DT_BAS_WEEK_COMPLETE: Final = DATE_BAS_WEEK_COMPLETE + "T" + TIME_BAS_COMPLETE + TZ_BAS
 
 # Duration formts
-D_DEFAULT = "P%P"
-D_WEEK = "P%p"
-D_ALT_EXT = "P" + DATE_EXT_COMPLETE + "T" + TIME_EXT_COMPLETE
-D_ALT_BAS = "P" + DATE_BAS_COMPLETE + "T" + TIME_BAS_COMPLETE
-D_ALT_EXT_ORD = "P" + DATE_EXT_ORD_COMPLETE + "T" + TIME_EXT_COMPLETE
-D_ALT_BAS_ORD = "P" + DATE_BAS_ORD_COMPLETE + "T" + TIME_BAS_COMPLETE
+D_DEFAULT: Final = "P%P"
+D_WEEK: Final = "P%p"
+D_ALT_EXT: Final = "P" + DATE_EXT_COMPLETE + "T" + TIME_EXT_COMPLETE
+D_ALT_BAS: Final = "P" + DATE_BAS_COMPLETE + "T" + TIME_BAS_COMPLETE
+D_ALT_EXT_ORD: Final = "P" + DATE_EXT_ORD_COMPLETE + "T" + TIME_EXT_COMPLETE
+D_ALT_BAS_ORD: Final = "P" + DATE_BAS_ORD_COMPLETE + "T" + TIME_BAS_COMPLETE
 
-STRF_DT_MAP: dict[str, Callable[[time | date, int], str]] = {
+STRF_DT_MAP: Final[Mapping[str, Callable[..., str]]] = {
     "%d": lambda tdt, yds: "%02d" % tdt.day,
     "%f": lambda tdt, yds: "%06d" % tdt.microsecond,
     "%H": lambda tdt, yds: "%02d" % tdt.hour,
@@ -78,7 +79,7 @@ STRF_DT_MAP: dict[str, Callable[[time | date, int], str]] = {
     "%%": lambda tdt, yds: "%",
 }
 
-STRF_D_MAP: dict[str, Callable[[timedelta | Duration, int], str]] = {
+STRF_D_MAP: Final[Mapping[str, Callable[..., str]]] = {
     "%d": lambda tdt, yds: "%02d" % tdt.days,
     "%f": lambda tdt, yds: "%06d" % tdt.microseconds,
     "%H": lambda tdt, yds: "%02d" % (tdt.seconds / 60 / 60),
@@ -94,7 +95,10 @@ STRF_D_MAP: dict[str, Callable[[timedelta | Duration, int], str]] = {
 }
 
 
-def _strfduration(tdt: timedelta | Duration, format: str, yeardigits: int=4) -> str:
+def _strfduration(tdt: DurationOrTimedelta,
+                  format: str,
+                  yeardigits: int = 4,
+                  ) -> str:
     """
     this is the work method for timedelta and Duration instances.
 
@@ -144,7 +148,10 @@ def _strfduration(tdt: timedelta | Duration, format: str, yeardigits: int=4) -> 
     return re.sub("%d|%f|%H|%m|%M|%S|%W|%Y|%C|%%|%P|%p", repl, format)
 
 
-def _strfdt(tdt: time | date, format: str, yeardigits: int=4) -> str:
+def _strfdt(tdt: time | date,
+            format: str,
+            yeardigits: int = 4,
+            ) -> str:
     """
     this is the work method for time and date instances.
 
@@ -162,7 +169,10 @@ def _strfdt(tdt: time | date, format: str, yeardigits: int=4) -> str:
     return re.sub("%d|%f|%H|%j|%m|%M|%S|%w|%W|%Y|%C|%z|%Z|%h|%%", repl, format)
 
 
-def strftime(tdt: timedelta | Duration | time | date, format: str, yeardigits: int=4) -> str:
+def strftime(tdt: DurationOrTimedelta | time | date,
+             format: str,
+             yeardigits: int = 4,
+             ) -> str:
     """Directive    Meaning    Notes
     %d    Day of the month as a decimal number [01,31].
     %f    Microsecond as a decimal number [0,999999], zero-padded

--- a/src/isodate/isotime.py
+++ b/src/isodate/isotime.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 
 import re
 from decimal import Decimal, ROUND_FLOOR
-from datetime import date, time, timedelta
-from typing import TYPE_CHECKING
+from datetime import date, time
 
-from isodate.duration import Duration
+from isodate.duration import DurationOrTimedelta
 from isodate.isostrf import strftime, TIME_EXT_COMPLETE, TZ_EXT
 from isodate.isoerror import ISO8601Error
 from isodate.isotzinfo import TZ_REGEX, build_tzinfo
@@ -91,6 +90,9 @@ def parse_time(timestring: str) -> time:
       +-hh:mm extended hours and minutes
       +-hh    hours
     """
+    microsecond: int | Decimal
+    second: int | Decimal
+    minute: int | Decimal
     isotimes = build_time_regexps()
     for pattern in isotimes:
         match = pattern.match(timestring)
@@ -148,7 +150,9 @@ def parse_time(timestring: str) -> time:
     raise ISO8601Error("Unrecognised ISO 8601 time format: %r" % timestring)
 
 
-def time_isoformat(ttime: timedelta | Duration | time | date, format: str=TIME_EXT_COMPLETE + TZ_EXT) -> str:
+def time_isoformat(ttime: DurationOrTimedelta | time | date,
+                   format: str = TIME_EXT_COMPLETE + TZ_EXT,
+                   ) -> str:
     """
     Format time strings.
 

--- a/src/isodate/isotzinfo.py
+++ b/src/isodate/isotzinfo.py
@@ -6,29 +6,49 @@ It offers a function to parse the time zone offset as specified by ISO 8601.
 from __future__ import annotations
 
 import re
-from typing import overload, TYPE_CHECKING
+from typing import Final, Literal, overload
 from datetime import datetime, tzinfo
 
 from isodate.isoerror import ISO8601Error
 from isodate.tzinfo import UTC, FixedOffset, ZERO, Utc
 
-if TYPE_CHECKING:
-    from typing_extensions import Literal
 
-TZ_REGEX = (
+TZ_REGEX: Final = (
     r"(?P<tzname>(Z|(?P<tzsign>[+-])" r"(?P<tzhour>[0-9]{2})(:?(?P<tzmin>[0-9]{2}))?)?)"
 )
 
-TZ_RE = re.compile(TZ_REGEX)
+TZ_RE: Final = re.compile(TZ_REGEX)
 
 
 @overload
-def build_tzinfo(tzname: Literal[""] | None, tzsign: str="+", tzhour: float=0, tzmin: float=0) -> None: ...
+def build_tzinfo(tzname: Literal[""] | None,
+                 tzsign: str = "+",
+                 tzhour: float = 0,
+                 tzmin: float = 0,
+                 ) -> None: ...
+
+
 @overload
-def build_tzinfo(tzname: Literal["Z"], tzsign: str="+", tzhour: float=0, tzmin: float=0) -> Utc: ...
+def build_tzinfo(tzname: Literal["Z"],
+                 tzsign: str = "+",
+                 tzhour: float = 0,
+                 tzmin: float = 0,
+                 ) -> Utc: ...
+
+
 @overload
-def build_tzinfo(tzname: str, tzsign: str="+", tzhour: float=0, tzmin: float=0) -> FixedOffset | Utc | None: ...
-def build_tzinfo(tzname: str | None, tzsign: str="+", tzhour: float=0, tzmin: float=0) -> FixedOffset | Utc | None:
+def build_tzinfo(tzname: str,
+                 tzsign: str = "+",
+                 tzhour: float = 0,
+                 tzmin: float = 0,
+                 ) -> FixedOffset | Utc | None: ...
+
+
+def build_tzinfo(tzname: str | None,
+                 tzsign: str = "+",
+                 tzhour: float = 0,
+                 tzmin: float = 0,
+                 ) -> FixedOffset | Utc | None:
     """
     create a tzinfo instance according to given parameters.
 
@@ -68,7 +88,7 @@ def parse_tzinfo(tzstring: str) -> tzinfo | None:
     raise ISO8601Error("%s not a valid time zone info" % tzstring)
 
 
-def tz_isoformat(dt: datetime, format: str="%Z") -> str:
+def tz_isoformat(dt: datetime, format: str = "%Z") -> str:
     """
     return time zone offset ISO 8601 formatted.
     The various ISO formats can be chosen with the format parameter.
@@ -87,6 +107,7 @@ def tz_isoformat(dt: datetime, format: str="%Z") -> str:
     if tzinfo.utcoffset(dt) == ZERO and tzinfo.dst(dt) == ZERO:
         return "Z"
     tdelta = tzinfo.utcoffset(dt)
+    assert tdelta is not None, "tdelta not None since tzinfo is not None"
     seconds = tdelta.days * 24 * 60 * 60 + tdelta.seconds
     sign = ((seconds < 0) and "-") or "+"
     seconds = abs(seconds)

--- a/src/isodate/tests/__init__.py
+++ b/src/isodate/tests/__init__.py
@@ -1,9 +1,12 @@
 """
 Collect all test suites into one TestSuite instance.
 """
+from __future__ import annotations
 
 import unittest
 import warnings
+from unittest import TestSuite
+
 from isodate.tests import (
     test_date,
     test_time,
@@ -14,7 +17,7 @@ from isodate.tests import (
 )
 
 
-def test_suite():
+def test_suite() -> TestSuite:
     """
     Return a new TestSuite instance consisting of all available TestSuites.
     """

--- a/src/isodate/tests/test_date.py
+++ b/src/isodate/tests/test_date.py
@@ -1,8 +1,13 @@
 """
 Test cases for the isodate module.
 """
+from __future__ import annotations
+
 import unittest
 from datetime import date
+from typing import Final, Mapping, Sequence
+from unittest import TestSuite, TestLoader
+
 from isodate import parse_date, ISO8601Error, date_isoformat
 from isodate import DATE_CENTURY, DATE_YEAR
 from isodate import DATE_BAS_MONTH, DATE_EXT_MONTH
@@ -11,11 +16,12 @@ from isodate import DATE_BAS_ORD_COMPLETE, DATE_EXT_ORD_COMPLETE
 from isodate import DATE_BAS_WEEK, DATE_BAS_WEEK_COMPLETE
 from isodate import DATE_EXT_WEEK, DATE_EXT_WEEK_COMPLETE
 
+
 # the following list contains tuples of ISO date strings and the expected
 # result from the parse_date method. A result of None means an ISO8601Error
 # is expected. The test cases are grouped into dates with 4 digit years
 # and 6 digit years.
-TEST_CASES = {
+TEST_CASES: Final[Mapping[int, Sequence[tuple[str, date | None, str]]]] = {
     4: [
         ("19", date(1901, 1, 1), DATE_CENTURY),
         ("1985", date(1985, 1, 1), DATE_YEAR),
@@ -49,7 +55,11 @@ TEST_CASES = {
 }
 
 
-def create_testcase(yeardigits, datestring, expectation, format):
+def create_testcase(yeardigits: int,
+                    datestring: str,
+                    expectation: date | None,
+                    format: str,
+                    ) -> TestSuite:
     """
     Create a TestCase class for a specific test.
 
@@ -63,7 +73,7 @@ def create_testcase(yeardigits, datestring, expectation, format):
         object.
         """
 
-        def test_parse(self):
+        def test_parse(self) -> None:
             """
             Parse an ISO date string and compare it to the expected value.
             """
@@ -73,7 +83,7 @@ def create_testcase(yeardigits, datestring, expectation, format):
                 result = parse_date(datestring, yeardigits)
                 self.assertEqual(result, expectation)
 
-        def test_format(self):
+        def test_format(self) -> None:
             """
             Take date object and create ISO string from it.
             This is the reverse test to test_parse.
@@ -90,7 +100,7 @@ def create_testcase(yeardigits, datestring, expectation, format):
     return unittest.TestLoader().loadTestsFromTestCase(TestDate)
 
 
-def test_suite():
+def test_suite() -> unittest.TestSuite:
     """
     Construct a TestSuite instance for all test cases.
     """
@@ -102,7 +112,10 @@ def test_suite():
 
 
 # load_tests Protocol
-def load_tests(loader, tests, pattern):
+def load_tests(loader: TestLoader,
+               tests: TestSuite,
+               pattern: str | None
+               ) -> unittest.TestSuite:
     return test_suite()
 
 

--- a/src/isodate/tests/test_datetime.py
+++ b/src/isodate/tests/test_datetime.py
@@ -1,8 +1,12 @@
 """
 Test cases for the isodatetime module.
 """
+from __future__ import annotations
+
 import unittest
 from datetime import datetime
+from typing import Final, Sequence
+from unittest import TestSuite, TestLoader
 
 from isodate import parse_datetime, UTC, FixedOffset, datetime_isoformat
 from isodate import ISO8601Error
@@ -12,10 +16,11 @@ from isodate import TZ_BAS, TZ_EXT, TZ_HOUR
 from isodate import DATE_BAS_ORD_COMPLETE, DATE_EXT_ORD_COMPLETE
 from isodate import DATE_BAS_WEEK_COMPLETE, DATE_EXT_WEEK_COMPLETE
 
+
 # the following list contains tuples of ISO datetime strings and the expected
 # result from the parse_datetime method. A result of None means an ISO8601Error
 # is expected.
-TEST_CASES = [
+TEST_CASES: Final[Sequence[tuple[str, datetime | None, str, str]]] = [
     (
         "19850412T1015",
         datetime(1985, 4, 12, 10, 15),
@@ -124,7 +129,11 @@ TEST_CASES = [
 ]
 
 
-def create_testcase(datetimestring, expectation, format, output):
+def create_testcase(datetimestring: str,
+                    expectation: datetime | None,
+                    format: str,
+                    output: str,
+                    ) -> TestSuite:
     """
     Create a TestCase class for a specific test.
 
@@ -138,7 +147,7 @@ def create_testcase(datetimestring, expectation, format, output):
         datetime object.
         """
 
-        def test_parse(self):
+        def test_parse(self) -> None:
             """
             Parse an ISO datetime string and compare it to the expected value.
             """
@@ -147,7 +156,7 @@ def create_testcase(datetimestring, expectation, format, output):
             else:
                 self.assertEqual(parse_datetime(datetimestring), expectation)
 
-        def test_format(self):
+        def test_format(self) -> None:
             """
             Take datetime object and create ISO string from it.
             This is the reverse test to test_parse.
@@ -162,7 +171,7 @@ def create_testcase(datetimestring, expectation, format, output):
     return unittest.TestLoader().loadTestsFromTestCase(TestDateTime)
 
 
-def test_suite():
+def test_suite() -> TestSuite:
     """
     Construct a TestSuite instance for all test cases.
     """
@@ -173,7 +182,10 @@ def test_suite():
 
 
 # load_tests Protocol
-def load_tests(loader, tests, pattern):
+def load_tests(loader: TestLoader,
+               tests: TestSuite,
+               pattern: str | None
+               ) -> unittest.TestSuite:
     return test_suite()
 
 

--- a/src/isodate/tests/test_duration.py
+++ b/src/isodate/tests/test_duration.py
@@ -1,17 +1,23 @@
 """
 Test cases for the isoduration module.
 """
+from __future__ import annotations
+
 import unittest
 import operator
 from datetime import timedelta, date, datetime
+from typing import Any, Final, Mapping, Sequence
+from unittest import TestLoader, TestSuite
 
 from isodate import Duration, parse_duration, ISO8601Error
 from isodate import D_DEFAULT, D_WEEK, D_ALT_EXT, duration_isoformat
+from isodate.duration import DurationOrTimedelta
+
 
 # the following list contains tuples of ISO duration strings and the expected
 # result from the parse_duration method. A result of None means an ISO8601Error
 # is expected.
-PARSE_TEST_CASES = {
+PARSE_TEST_CASES: Final[Mapping[str, tuple[DurationOrTimedelta, str, str | None]]] = {
     "P18Y9M4DT11H9M8S": (Duration(4, 8, 0, 0, 9, 11, 0, 9, 18), D_DEFAULT, None),
     "P2W": (timedelta(weeks=2), D_WEEK, None),
     "P3Y6M4DT12H30M5S": (Duration(4, 5, 0, 0, 30, 12, 0, 6, 3), D_DEFAULT, None),
@@ -52,7 +58,7 @@ PARSE_TEST_CASES = {
 # each tuple contains 2 duration strings, and a result string for addition and
 # one for subtraction. The last value says, if the first duration is greater
 # than the second.
-MATH_TEST_CASES = (
+MATH_TEST_CASES: Final[Sequence[tuple[str, str, str, str, bool | None]]] = (
     (
         "P5Y7M1DT9H45M16.72S",
         "PT27M24.68S",
@@ -89,7 +95,7 @@ MATH_TEST_CASES = (
 # A list of test cases to test addition and subtraction of date/datetime
 # and Duration objects. They are tested against the results of an
 # equal long timedelta duration.
-DATE_TEST_CASES = (
+DATE_TEST_CASES: Final[Sequence[tuple[date, DurationOrTimedelta, Duration]]] = (
     (
         date(2008, 2, 29),
         timedelta(days=10, hours=12, minutes=20),
@@ -135,7 +141,7 @@ DATE_TEST_CASES = (
 
 # A list of test cases of addition of date/datetime and Duration. The results
 # are compared against a given expected result.
-DATE_CALC_TEST_CASES = (
+DATE_CALC_TEST_CASES: Final[Sequence[tuple[Any, Any, Any]]] = (
     (date(2000, 2, 1), Duration(years=1, months=1), date(2001, 3, 1)),
     (date(2000, 2, 29), Duration(years=1, months=1), date(2001, 3, 29)),
     (date(2000, 2, 29), Duration(years=1), date(2001, 2, 28)),
@@ -199,7 +205,7 @@ DATE_CALC_TEST_CASES = (
 
 # A list of test cases of multiplications of durations
 # are compared against a given expected result.
-DATE_MUL_TEST_CASES = (
+DATE_MUL_TEST_CASES: Final[Sequence[tuple[Any, Any, Duration]]] = (
     (Duration(years=1, months=1), 3, Duration(years=3, months=3)),
     (Duration(years=1, months=1), -3, Duration(years=-3, months=-3)),
     (3, Duration(years=1, months=1), Duration(years=3, months=3)),
@@ -216,7 +222,7 @@ class DurationTest(unittest.TestCase):
     which are not covered with the test cases listed above.
     """
 
-    def test_associative(self):
+    def test_associative(self) -> None:
         """
         Adding 2 durations to a date is not associative.
         """
@@ -227,7 +233,7 @@ class DurationTest(unittest.TestCase):
         res2 = start + months1 + days1
         self.assertNotEqual(res1, res2)
 
-    def test_typeerror(self):
+    def test_typeerror(self) -> None:
         """
         Test if TypError is raised with certain parameters.
         """
@@ -265,13 +271,13 @@ class DurationTest(unittest.TestCase):
             TypeError, operator.mul, 3.14, Duration(years=1, months=1, weeks=5)
         )
 
-    def test_parseerror(self):
+    def test_parseerror(self) -> None:
         """
         Test for unparsable duration string.
         """
         self.assertRaises(ISO8601Error, parse_duration, "T10:10:10")
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         """
         Test __repr__ and __str__ for Duration objects.
         """
@@ -285,7 +291,7 @@ class DurationTest(unittest.TestCase):
         dur = Duration(months=1)
         self.assertEqual("1 month, 0:00:00", str(dur))
 
-    def test_hash(self):
+    def test_hash(self) -> None:
         """
         Test __hash__ for Duration objects.
         """
@@ -302,7 +308,7 @@ class DurationTest(unittest.TestCase):
         durSet.add(dur3)
         self.assertEqual(len(durSet), 2)
 
-    def test_neg(self):
+    def test_neg(self) -> None:
         """
         Test __neg__ for Duration objects.
         """
@@ -315,7 +321,7 @@ class DurationTest(unittest.TestCase):
         #        treats a == b the same b == a
         # self.assertNotEqual(-timedelta(days=10), -Duration(days=10))
 
-    def test_format(self):
+    def test_format(self) -> None:
         """
         Test various other strftime combinations.
         """
@@ -332,7 +338,7 @@ class DurationTest(unittest.TestCase):
         self.assertEqual(duration_isoformat(dur), "P3Y7M23DT5H25M0.33S")
         self.assertEqual(duration_isoformat(-dur), "-P3Y7M23DT5H25M0.33S")
 
-    def test_equal(self):
+    def test_equal(self) -> None:
         """
         Test __eq__ and __ne__ methods.
         """
@@ -351,7 +357,7 @@ class DurationTest(unittest.TestCase):
         #        treats a != b the same b != a
         # self.assertNotEqual(timedelta(days=1), Duration(days=1))
 
-    def test_totimedelta(self):
+    def test_totimedelta(self) -> None:
         """
         Test conversion form Duration to timedelta.
         """
@@ -367,7 +373,11 @@ class DurationTest(unittest.TestCase):
         self.assertEqual(dur.totimedelta(datetime(2001, 3, 25)), timedelta(61))
 
 
-def create_parsetestcase(durationstring, expectation, format, altstr):
+def create_parsetestcase(durationstring: str,
+                         expectation: DurationOrTimedelta,
+                         format: str,
+                         altstr: str | None,
+                         ) -> TestSuite:
     """
     Create a TestCase class for a specific test.
 
@@ -381,14 +391,14 @@ def create_parsetestcase(durationstring, expectation, format, altstr):
         timedelta or Duration object.
         """
 
-        def test_parse(self):
+        def test_parse(self) -> None:
             """
             Parse an ISO duration string and compare it to the expected value.
             """
             result = parse_duration(durationstring)
             self.assertEqual(result, expectation)
 
-        def test_format(self):
+        def test_format(self) -> None:
             """
             Take duration/timedelta object and create ISO string from it.
             This is the reverse test to test_parse.
@@ -405,7 +415,12 @@ def create_parsetestcase(durationstring, expectation, format, altstr):
     return unittest.TestLoader().loadTestsFromTestCase(TestParseDuration)
 
 
-def create_mathtestcase(dur1, dur2, resadd, ressub, resge):
+def create_mathtestcase(dur1_str: str,
+                        dur2_str: str,
+                        resadd_str: str,
+                        ressub_str: str,
+                        resge: bool | None,
+                        ) -> TestSuite:
     """
     Create a TestCase class for a specific test.
 
@@ -413,10 +428,10 @@ def create_mathtestcase(dur1, dur2, resadd, ressub, resge):
     MATH_TEST_CASES list, so that a failed test won't stop other tests.
     """
 
-    dur1 = parse_duration(dur1)
-    dur2 = parse_duration(dur2)
-    resadd = parse_duration(resadd)
-    ressub = parse_duration(ressub)
+    dur1 = parse_duration(dur1_str)
+    dur2 = parse_duration(dur2_str)
+    resadd = parse_duration(resadd_str)
+    ressub = parse_duration(ressub_str)
 
     class TestMathDuration(unittest.TestCase):
         """
@@ -424,30 +439,30 @@ def create_mathtestcase(dur1, dur2, resadd, ressub, resge):
         operators for Duration objects.
         """
 
-        def test_add(self):
+        def test_add(self) -> None:
             """
             Test operator + (__add__, __radd__)
             """
             self.assertEqual(dur1 + dur2, resadd)
 
-        def test_sub(self):
+        def test_sub(self) -> None:
             """
             Test operator - (__sub__, __rsub__)
             """
             self.assertEqual(dur1 - dur2, ressub)
 
-        def test_ge(self):
+        def test_ge(self) -> None:
             """
             Test operator > and <
             """
 
-            def dogetest():
+            def dogetest() -> bool:
                 """Test greater than."""
-                return dur1 > dur2
+                return dur1 > dur2  # type: ignore  # may raise TypeError
 
-            def doletest():
+            def doletest() -> bool:
                 """Test less than."""
-                return dur1 < dur2
+                return dur1 < dur2  # type: ignore  # may raise TypeError
 
             if resge is None:
                 self.assertRaises(TypeError, dogetest)
@@ -459,7 +474,10 @@ def create_mathtestcase(dur1, dur2, resadd, ressub, resge):
     return unittest.TestLoader().loadTestsFromTestCase(TestMathDuration)
 
 
-def create_datetestcase(start, tdelta, duration):
+def create_datetestcase(start: date,
+                        tdelta: DurationOrTimedelta,
+                        duration: Duration,
+                        ) -> TestSuite:
     """
     Create a TestCase class for a specific test.
 
@@ -473,13 +491,13 @@ def create_datetestcase(start, tdelta, duration):
         operators for Duration objects.
         """
 
-        def test_add(self):
+        def test_add(self) -> None:
             """
             Test operator +.
             """
             self.assertEqual(start + tdelta, start + duration)
 
-        def test_sub(self):
+        def test_sub(self) -> None:
             """
             Test operator -.
             """
@@ -488,7 +506,7 @@ def create_datetestcase(start, tdelta, duration):
     return unittest.TestLoader().loadTestsFromTestCase(TestDateCalc)
 
 
-def create_datecalctestcase(start, duration, expectation):
+def create_datecalctestcase(start: Any, duration: Any, expectation: Any) -> TestSuite:
     """
     Create a TestCase class for a specific test.
 
@@ -501,7 +519,7 @@ def create_datecalctestcase(start, duration, expectation):
         A test case template test addition operators for Duration objects.
         """
 
-        def test_calc(self):
+        def test_calc(self) -> None:
             """
             Test operator +.
             """
@@ -513,7 +531,10 @@ def create_datecalctestcase(start, duration, expectation):
     return unittest.TestLoader().loadTestsFromTestCase(TestDateCalc)
 
 
-def create_datemultestcase(operand1, operand2, expectation):
+def create_datemultestcase(operand1: Any,
+                           operand2: Any,
+                           expectation: Duration,
+                           ) -> TestSuite:
     """
     Create a TestCase class for a specific test.
 
@@ -526,7 +547,7 @@ def create_datemultestcase(operand1, operand2, expectation):
         A test case template test addition operators for Duration objects.
         """
 
-        def test_mul(self):
+        def test_mul(self) -> None:
             """
             Test operator *.
             """
@@ -535,27 +556,30 @@ def create_datemultestcase(operand1, operand2, expectation):
     return unittest.TestLoader().loadTestsFromTestCase(TestDateMul)
 
 
-def test_suite():
+def test_suite() -> unittest.TestSuite:
     """
     Return a test suite containing all test defined above.
     """
     suite = unittest.TestSuite()
     for durationstring, (expectation, format, altstr) in PARSE_TEST_CASES.items():
         suite.addTest(create_parsetestcase(durationstring, expectation, format, altstr))
-    for testdata in MATH_TEST_CASES:
-        suite.addTest(create_mathtestcase(*testdata))
-    for testdata in DATE_TEST_CASES:
-        suite.addTest(create_datetestcase(*testdata))
-    for testdata in DATE_CALC_TEST_CASES:
-        suite.addTest(create_datecalctestcase(*testdata))
-    for testdata in DATE_MUL_TEST_CASES:
-        suite.addTest(create_datemultestcase(*testdata))
+    for math_data in MATH_TEST_CASES:
+        suite.addTest(create_mathtestcase(*math_data))
+    for date_data in DATE_TEST_CASES:
+        suite.addTest(create_datetestcase(*date_data))
+    for date_calc_data in DATE_CALC_TEST_CASES:
+        suite.addTest(create_datecalctestcase(*date_calc_data))
+    for date_mul_data in DATE_MUL_TEST_CASES:
+        suite.addTest(create_datemultestcase(*date_mul_data))
     suite.addTest(unittest.TestLoader().loadTestsFromTestCase(DurationTest))
     return suite
 
 
 # load_tests Protocol
-def load_tests(loader, tests, pattern):
+def load_tests(loader: TestLoader,
+               tests: TestSuite,
+               pattern: str | None,
+               ) -> unittest.TestSuite:
     return test_suite()
 
 

--- a/src/isodate/tests/test_pickle.py
+++ b/src/isodate/tests/test_pickle.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import unittest
 
 import pickle
+from unittest import TestLoader, TestSuite
 
 import isodate
 
@@ -11,7 +14,7 @@ class TestPickle(unittest.TestCase):
     datetime object.
     """
 
-    def test_pickle_datetime(self):
+    def test_pickle_datetime(self) -> None:
         """
         Parse an ISO datetime string and compare it to the expected value.
         """
@@ -20,7 +23,7 @@ class TestPickle(unittest.TestCase):
             pikl = pickle.dumps(dti, proto)
             self.assertEqual(dti, pickle.loads(pikl), "pickle proto %d failed" % proto)
 
-    def test_pickle_duration(self):
+    def test_pickle_duration(self) -> None:
         """
         Pickle / unpickle duration objects.
         """
@@ -37,14 +40,14 @@ class TestPickle(unittest.TestCase):
                 failed.append("pickle proto %d failed (%s)" % (proto, repr(e)))
         self.assertEqual(len(failed), 0, "pickle protos failed: %s" % str(failed))
 
-    def test_pickle_utc(self):
+    def test_pickle_utc(self) -> None:
         """
         isodate.UTC objects remain the same after pickling.
         """
         self.assertTrue(isodate.UTC is pickle.loads(pickle.dumps(isodate.UTC)))
 
 
-def test_suite():
+def test_suite() -> TestSuite:
     """
     Construct a TestSuite instance for all test cases.
     """
@@ -54,7 +57,10 @@ def test_suite():
 
 
 # load_tests Protocol
-def load_tests(loader, tests, pattern):
+def load_tests(loader: TestLoader,
+               tests: TestSuite,
+               pattern: str | None,
+               ) -> unittest.TestSuite:
     return test_suite()
 
 

--- a/src/isodate/tests/test_strf.py
+++ b/src/isodate/tests/test_strf.py
@@ -1,16 +1,21 @@
 """
 Test cases for the isodate module.
 """
+from __future__ import annotations
+
 import unittest
 import time
 from datetime import datetime, timedelta
+from typing import Any, Final, Mapping, Sequence
+from unittest import TestSuite, TestLoader
+
 from isodate import strftime
 from isodate import LOCAL
 from isodate import DT_EXT_COMPLETE
 from isodate import tzinfo
 
 
-TEST_CASES = (
+TEST_CASES: Final[Sequence[tuple[datetime, str, str]]] = (
     (
         datetime(2012, 12, 25, 13, 30, 0, 0, LOCAL),
         DT_EXT_COMPLETE,
@@ -36,7 +41,7 @@ TEST_CASES = (
 )
 
 
-def create_testcase(dt, format, expectation):
+def create_testcase(dt: datetime, format: str, expectation: str) -> TestSuite:
     """
     Create a TestCase class for a specific test.
 
@@ -50,7 +55,7 @@ def create_testcase(dt, format, expectation):
         """
 
         # local time zone mock function
-        def localtime_mock(self, secs):
+        def localtime_mock(self, secs: float | None = None) -> time.struct_time:
             """
             mock time.localtime so that it always returns a time_struct with
             tm_idst=1
@@ -74,12 +79,13 @@ def create_testcase(dt, format, expectation):
             )
             return time.struct_time(tt)
 
-        def setUp(self):
-            self.ORIG = {}
-            self.ORIG["STDOFFSET"] = tzinfo.STDOFFSET
-            self.ORIG["DSTOFFSET"] = tzinfo.DSTOFFSET
-            self.ORIG["DSTDIFF"] = tzinfo.DSTDIFF
-            self.ORIG["localtime"] = time.localtime
+        def setUp(self) -> None:
+            self.ORIG: Mapping[str, Any] = {
+                "STDOFFSET": tzinfo.STDOFFSET,
+                "DSTOFFSET": tzinfo.DSTOFFSET,
+                "DSTDIFF": tzinfo.DSTDIFF,
+                "localtime": time.localtime,
+            }
             # override all saved values with fixtures.
             # calculate LOCAL TZ offset, so that this test runs in
             # every time zone
@@ -88,14 +94,14 @@ def create_testcase(dt, format, expectation):
             tzinfo.DSTDIFF = tzinfo.DSTOFFSET - tzinfo.STDOFFSET
             time.localtime = self.localtime_mock
 
-        def tearDown(self):
+        def tearDown(self) -> None:
             # restore test fixtures
             tzinfo.STDOFFSET = self.ORIG["STDOFFSET"]
             tzinfo.DSTOFFSET = self.ORIG["DSTOFFSET"]
             tzinfo.DSTDIFF = self.ORIG["DSTDIFF"]
             time.localtime = self.ORIG["localtime"]
 
-        def test_format(self):
+        def test_format(self) -> None:
             """
             Take date object and create ISO string from it.
             This is the reverse test to test_parse.
@@ -108,7 +114,7 @@ def create_testcase(dt, format, expectation):
     return unittest.TestLoader().loadTestsFromTestCase(TestDate)
 
 
-def test_suite():
+def test_suite() -> TestSuite:
     """
     Construct a TestSuite instance for all test cases.
     """
@@ -119,7 +125,10 @@ def test_suite():
 
 
 # load_tests Protocol
-def load_tests(loader, tests, pattern):
+def load_tests(loader: TestLoader,
+               tests: TestSuite,
+               pattern: str | None,
+               ) -> unittest.TestSuite:
     return test_suite()
 
 

--- a/src/isodate/tests/test_strf.py
+++ b/src/isodate/tests/test_strf.py
@@ -106,10 +106,7 @@ def create_testcase(dt: datetime, format: str, expectation: str) -> TestSuite:
             Take date object and create ISO string from it.
             This is the reverse test to test_parse.
             """
-            if expectation is None:
-                self.assertRaises(AttributeError, strftime(dt, format))
-            else:
-                self.assertEqual(strftime(dt, format), expectation)
+            self.assertEqual(strftime(dt, format), expectation)
 
     return unittest.TestLoader().loadTestsFromTestCase(TestDate)
 

--- a/src/isodate/tests/test_time.py
+++ b/src/isodate/tests/test_time.py
@@ -1,8 +1,12 @@
 """
 Test cases for the isotime module.
 """
+from __future__ import annotations
+
 import unittest
 from datetime import time
+from typing import Final, Sequence
+from unittest import TestLoader, TestSuite
 
 from isodate import parse_time, UTC, FixedOffset, ISO8601Error, time_isoformat
 from isodate import TIME_BAS_COMPLETE, TIME_BAS_MINUTE
@@ -10,10 +14,11 @@ from isodate import TIME_EXT_COMPLETE, TIME_EXT_MINUTE
 from isodate import TIME_HOUR
 from isodate import TZ_BAS, TZ_EXT, TZ_HOUR
 
+
 # the following list contains tuples of ISO time strings and the expected
 # result from the parse_time method. A result of None means an ISO8601Error
 # is expected.
-TEST_CASES = [
+TEST_CASES: Final[Sequence[tuple[str, time | None, str | None]]] = [
     ("232050", time(23, 20, 50), TIME_BAS_COMPLETE + TZ_BAS),
     ("23:20:50", time(23, 20, 50), TIME_EXT_COMPLETE + TZ_EXT),
     ("2320", time(23, 20), TIME_BAS_MINUTE),
@@ -92,7 +97,10 @@ TEST_CASES = [
 ]
 
 
-def create_testcase(timestring, expectation, format):
+def create_testcase(timestring: str,
+                    expectation: time | None,
+                    format: str | None,
+                    ) -> unittest.TestSuite:
     """
     Create a TestCase class for a specific test.
 
@@ -106,7 +114,7 @@ def create_testcase(timestring, expectation, format):
         object.
         """
 
-        def test_parse(self):
+        def test_parse(self) -> None:
             """
             Parse an ISO time string and compare it to the expected value.
             """
@@ -116,7 +124,7 @@ def create_testcase(timestring, expectation, format):
                 result = parse_time(timestring)
                 self.assertEqual(result, expectation)
 
-        def test_format(self):
+        def test_format(self) -> None:
             """
             Take time object and create ISO string from it.
             This is the reverse test to test_parse.
@@ -129,7 +137,7 @@ def create_testcase(timestring, expectation, format):
     return unittest.TestLoader().loadTestsFromTestCase(TestTime)
 
 
-def test_suite():
+def test_suite() -> unittest.TestSuite:
     """
     Construct a TestSuite instance for all test cases.
     """
@@ -140,7 +148,10 @@ def test_suite():
 
 
 # load_tests Protocol
-def load_tests(loader, tests, pattern):
+def load_tests(loader: TestLoader,
+               tests: TestSuite,
+               pattern: str | None,
+               ) -> unittest.TestSuite:
     return test_suite()
 
 

--- a/src/isodate/tzinfo.py
+++ b/src/isodate/tzinfo.py
@@ -105,13 +105,13 @@ class FixedOffset(tzinfo):
         return "<FixedOffset %r>" % self.__name
 
 
-STDOFFSET: Final = timedelta(seconds=-time.timezone)
+STDOFFSET = timedelta(seconds=-time.timezone)
 # locale time zone offset
 
 # calculate local daylight saving offset if any.
-DSTOFFSET: Final = timedelta(seconds=-time.altzone) if time.daylight else STDOFFSET
+DSTOFFSET = timedelta(seconds=-time.altzone) if time.daylight else STDOFFSET
 
-DSTDIFF: Final = DSTOFFSET - STDOFFSET
+DSTDIFF = DSTOFFSET - STDOFFSET
 # difference between local time zone and local DST time zone
 
 

--- a/src/isodate/tzinfo.py
+++ b/src/isodate/tzinfo.py
@@ -6,13 +6,11 @@ All those classes are taken from the Python documentation.
 from __future__ import annotations
 
 import time
-from typing import Callable, TYPE_CHECKING
+from typing import Callable, Final, Literal
 from datetime import datetime, timedelta, tzinfo
 
-if TYPE_CHECKING:
-    from typing_extensions import Literal
 
-ZERO = timedelta(0)
+ZERO: Final = timedelta(0)
 # constant for zero time offset.
 
 
@@ -42,14 +40,14 @@ class Utc(tzinfo):
         """
         return ZERO
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple[Callable[[], Utc], tuple[()]]:
         """
         When unpickling a Utc object, return the default instance below, UTC.
         """
         return _Utc, ()
 
 
-UTC = Utc()
+UTC: Final = Utc()
 # the default instance for UTC.
 
 
@@ -68,7 +66,10 @@ class FixedOffset(tzinfo):
     build a UTC tzinfo object.
     """
 
-    def __init__(self, offset_hours: float=0, offset_minutes: float=0, name: str="UTC") -> None:
+    def __init__(self, offset_hours: float = 0,
+                 offset_minutes: float = 0,
+                 name: str = "UTC",
+                 ) -> None:
         """
         Initialise an instance with time offset and name.
         The time offset should be positive for time zones east of UTC
@@ -104,13 +105,13 @@ class FixedOffset(tzinfo):
         return "<FixedOffset %r>" % self.__name
 
 
-STDOFFSET = timedelta(seconds=-time.timezone)
+STDOFFSET: Final = timedelta(seconds=-time.timezone)
 # locale time zone offset
 
 # calculate local daylight saving offset if any.
-DSTOFFSET = timedelta(seconds=-time.altzone) if time.daylight else STDOFFSET
+DSTOFFSET: Final = timedelta(seconds=-time.altzone) if time.daylight else STDOFFSET
 
-DSTDIFF = DSTOFFSET - STDOFFSET
+DSTDIFF: Final = DSTOFFSET - STDOFFSET
 # difference between local time zone and local DST time zone
 
 
@@ -167,4 +168,4 @@ class LocalTimezone(tzinfo):
 
 
 # the default instance for local time zone.
-LOCAL = LocalTimezone()
+LOCAL: Final = LocalTimezone()

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{37, 38, 39, 310, py3}
+    py{38, 39, 310, py3}
 
 [testenv]
 deps =


### PR DESCRIPTION
- **Drop support for Python <= 3.7 90a6981dab536ff4c13a73dd9ab34b14dcbc8a78**
  - 3.7 is EOL and uses different return type variance in date/datime
  - CHANGES file already calls for removal of unsupported versions

- **Add mypy to pre-commit df501cb04754ee9499940ffca34490c15c32871f**
- **feat: Improve type annotations. mypy now passes on isodate itself c1d278ce5012063c941b006d1e5227511158dc1e**
  - Improve annotation and make sure that isodate itself can be checked with mypy --strict 
  - Bring minor behavior preserving code changes to help the type checker
    - Add assert, cast, or an extra variables to help mypy as needed
  - Type all untyped functions
  - Add DurationOrTimedelta: TypeAlias
  - Use overloads and TypeVar to help infer the return type of some functions
  - Mark module level constants as Final
  - Take advantage that datetime derives from date (though this is less explicit)
- **test: Add type annotations to tests and setup.py 834f91dc5e0cf35913bb936396c5b2ce9985b748**
  - This helps to exercise the types in the library.
  - This commit may be reverted if type annotations outside the implementation itself are deemed too high maintenance.
